### PR TITLE
Some fixes?

### DIFF
--- a/environ.yaml
+++ b/environ.yaml
@@ -119,7 +119,7 @@ dependencies:
     - fastjsonschema==2.15.3
     - filelock==3.4.2
     - fonttools==4.32.0
-    - gdown==4.2.0
+    - gdown==4.7.1
     - google-auth==2.5.0
     - google-auth-oauthlib==0.4.6
     - grpcio==1.43.0

--- a/models/dataset.py
+++ b/models/dataset.py
@@ -11,7 +11,6 @@ from scipy.spatial.transform import Slerp
 
 
 def compose_transf(P1, P2):
-
     R1 = P1[:3,:3]
     T1 = P1[:3,3:4]
     R2 = P2[:3,:3]
@@ -21,6 +20,7 @@ def compose_transf(P1, P2):
     T = T1 + R1@T2
     return np.concatenate([R,T], axis=-1)
 
+
 def make4x4(P):
     assert P.shape[-1] == 4
     assert len(P.shape) == 2
@@ -28,6 +28,7 @@ def make4x4(P):
     ret = np.eye(4)
     ret[:P.shape[0]] = P
     return ret
+
 
 # This function is borrowed from IDR: https://github.com/lioryariv/idr
 def load_K_Rt_from_P(filename, P=None):
@@ -53,8 +54,10 @@ def load_K_Rt_from_P(filename, P=None):
 
     return intrinsics, pose
 
+
 def img_id(path):
     return int(os.path.splitext(os.path.basename(path))[0])
+
 
 class Dataset:
     def __init__(self, conf, load_images=True):
@@ -73,7 +76,7 @@ class Dataset:
 
         camera_dict = np.load(os.path.join(self.data_dir, self.render_cameras_name))
         self.camera_dict = camera_dict
-        
+
         if load_images:
             if os.path.exists(os.path.join(self.data_dir, 'images.npy')):
                 self.images_np = np.load(os.path.join(self.data_dir, 'images.npy'))
@@ -81,9 +84,8 @@ class Dataset:
                 self.images_np = self.images_np / max_intensity * 5
                 self.saturation_intensity = 5
                 self.images_id = list(range(len(self.images_np)))
-                
 
-            elif len(glob(os.path.join(self.data_dir, 'image/*.exr'))) > 0: 
+            elif len(glob(os.path.join(self.data_dir, 'image/*.exr'))) > 0:
                 # exr format
                 self.images_lis = sorted(glob(os.path.join(self.data_dir, 'image/*.exr')))
                 self.images_np = np.stack([cv.imread(im_name, -1)[...,2::-1] for im_name in self.images_lis])
@@ -95,9 +97,8 @@ class Dataset:
                 self.images_np = np.stack([cv.imread(im_name)[...,::-1] for im_name in self.images_lis]) / 256.0
                 self.saturation_intensity = float(camera_dict.get("max_intensity", 255 / 256.0 - 0.001))
                 self.images_id = [img_id(p) for p in self.images_lis]
-    
+
             self.n_images = len(self.images_np)
-        
 
             if conf.get('ignore_mask', False):
                 self.masks_np = np.ones_like(self.images_np)
@@ -105,12 +106,11 @@ class Dataset:
             else:
                 mask_dic = {img_id(p):p for p in glob(os.path.join(self.data_dir, 'mask/*.png'))}
                 self.masks_lis = [mask_dic[i] for i in self.images_id]
-                self.masks_np = (np.stack([cv.imread(im_name) for im_name in self.masks_lis]) / 256.0 > 0.5).astype(np.float) 
+                self.masks_np = (np.stack([cv.imread(im_name) for im_name in self.masks_lis]) / 256.0 > 0.5).astype(np.float)
                 self.no_mask = False
 
-            
             self.images = torch.from_numpy(self.images_np.astype(np.float32)).cpu()  # [n_images, H, W, 3]
-            self.masks  = torch.from_numpy(self.masks_np.astype(np.float32)).cpu()   # [n_images, H, W, 3]
+            self.masks = torch.from_numpy(self.masks_np.astype(np.float32)).cpu()  # [n_images, H, W, 3]
             self.H, self.W = self.images.shape[1], self.images.shape[2]
             self.image_pixels = self.H * self.W
 
@@ -122,7 +122,7 @@ class Dataset:
             self.n_images = len(self.images_id)
             # example_input = cv.imread(glob(os.path.join(self.data_dir, 'mask/*.png'))[0])
             # self.H, self.W = example_input.shape[0], example_input.shape[1]
-            
+
         # world_mat is a projection matrix from world to image
         self.world_mats_np = [camera_dict['world_mat_%d' % idx].astype(np.float32) for idx in self.images_id]
 
@@ -150,19 +150,22 @@ class Dataset:
 
         self.intrinsics_all = self.intrinsics_all.to(self.device)  # [n_images, 4, 4]
         self.intrinsics_all_inv = self.intrinsics_all_inv.to(self.device)  # [n_images, 4, 4]
-        
+
         self.focal = self.intrinsics_all[0][0, 0]
         self.pose_all = torch.stack(self.pose_all).to(self.device)  # [n_images, 4, 4]
 
         object_bbox_min = np.array([-1.01, -1.01, -1.01, 1.0])
-        object_bbox_max = np.array([ 1.01,  1.01,  1.01, 1.0])
+        object_bbox_max = np.array([1.01, 1.01, 1.01, 1.0])
         # Object scale mat: region of interest to **extract mesh**
-        object_scale_mat = make4x4(np.load(os.path.join(self.data_dir, self.object_cameras_name))['scale_mat_0'])
+        # get lexicographically ordered first scale_mat
+        object_camera_dict = np.load(os.path.join(self.data_dir, self.object_cameras_name))
+        scale_mat_names = sorted([k for k in object_camera_dict.keys() if 'scale_mat' in k])
+        object_scale_mat = make4x4(object_camera_dict[scale_mat_names[0]])
         object_bbox_min = np.linalg.inv(self.scale_mats_np[0]) @ object_scale_mat @ object_bbox_min[:, None]
         object_bbox_max = np.linalg.inv(self.scale_mats_np[0]) @ object_scale_mat @ object_bbox_max[:, None]
         self.object_bbox_min = object_bbox_min[:3, 0]
         self.object_bbox_max = object_bbox_max[:3, 0]
-
+        return
 
     def cap_pixel_val(self, img_idx):
         return self.saturation_intensity
@@ -175,10 +178,10 @@ class Dataset:
         tx = torch.linspace(0, self.W - 1, self.W // l)
         ty = torch.linspace(0, self.H - 1, self.H // l)
         pixels_x, pixels_y = torch.meshgrid(tx, ty)
-        p = torch.stack([pixels_x, pixels_y, torch.ones_like(pixels_y)], dim=-1) # W, H, 3
+        p = torch.stack([pixels_x, pixels_y, torch.ones_like(pixels_y)], dim=-1)  # W, H, 3
         p = torch.matmul(self.intrinsics_all_inv[img_idx, None, None, :3, :3], p[:, :, :, None]).squeeze()  # W, H, 3
         rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)  # W, H, 3
-        return rays_v[:,:,2].transpose(0, 1)
+        return rays_v[:, :, 2].transpose(0, 1)
 
     def gen_rays_at(self, img_idx, resolution_level=1):
         """
@@ -188,7 +191,7 @@ class Dataset:
         tx = torch.linspace(0, self.W - 1, self.W // l)
         ty = torch.linspace(0, self.H - 1, self.H // l)
         pixels_x, pixels_y = torch.meshgrid(tx, ty)
-        p = torch.stack([pixels_x, pixels_y, torch.ones_like(pixels_y)], dim=-1) # W, H, 3
+        p = torch.stack([pixels_x, pixels_y, torch.ones_like(pixels_y)], dim=-1)  # W, H, 3
         p = torch.matmul(self.intrinsics_all_inv[img_idx, None, None, :3, :3], p[:, :, :, None]).squeeze()  # W, H, 3
         rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)  # W, H, 3
         rays_v = torch.matmul(self.pose_all[img_idx, None, None, :3, :3], rays_v[:, :, :, None]).squeeze()  # W, H, 3
@@ -200,11 +203,11 @@ class Dataset:
         light_lum = torch.from_numpy(self.light_energies[img_idx]).cuda()
         return light_o, light_lum
 
-    def gen_random_rays_patch(self, img_idx, patch_size, foreground_only=True, shift=(0,0), seed=None):
+    def gen_random_rays_patch(self, img_idx, patch_size, foreground_only=True, shift=(0, 0), seed=None):
         if seed is not None:
             np.random.seed(seed)
         patch_size = min(patch_size, self.W, self.H)
-        assert all((s-0.5)*(s+0.5)<=0 for s in shift)
+        assert all((s - 0.5) * (s + 0.5) <= 0 for s in shift)
         if foreground_only:
             for i in range(10):
                 patch_origin_x = np.random.randint(0, self.W - patch_size)
@@ -213,26 +216,26 @@ class Dataset:
                 pixels_x = (pixels_x + patch_origin_x).reshape(-1)
                 pixels_y = (pixels_y + patch_origin_y).reshape(-1)
 
-                color = self.images[img_idx][(pixels_y, pixels_x)]    # batch_size, 3
-                mask = self.masks[img_idx][(pixels_y, pixels_x)]      # batch_size, 3
+                color = self.images[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
+                mask = self.masks[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
                 if mask.sum() > 0:
                     break
-            
-            if mask.sum() == 0: # failed too many times, revert to mask sampling
+
+            if mask.sum() == 0:  # failed too many times, revert to mask sampling
                 pixels_y, pixels_x = torch.meshgrid(torch.arange(self.H), torch.arange(self.W))
-                pixels_x = pixels_x[self.masks[img_idx].mean(-1) > 0.5] 
+                pixels_x = pixels_x[self.masks[img_idx].mean(-1) > 0.5]
                 pixels_y = pixels_y[self.masks[img_idx].mean(-1) > 0.5]
 
                 choice = torch.from_numpy(np.random.choice(len(pixels_x), 1, replace=False))
-                patch_origin_x = min(int(pixels_x[choice[0]]), self.W-patch_size)
-                patch_origin_y = min(int(pixels_y[choice[0]]), self.H-patch_size)
+                patch_origin_x = min(int(pixels_x[choice[0]]), self.W - patch_size)
+                patch_origin_y = min(int(pixels_y[choice[0]]), self.H - patch_size)
 
                 pixels_y, pixels_x = torch.meshgrid(torch.arange(patch_size), torch.arange(patch_size))
                 pixels_x = (pixels_x + patch_origin_x).reshape(-1)
                 pixels_y = (pixels_y + patch_origin_y).reshape(-1)
 
-                color = self.images[img_idx][(pixels_y, pixels_x)]    # batch_size, 3
-                mask = self.masks[img_idx][(pixels_y, pixels_x)]      # batch_size, 3
+                color = self.images[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
+                mask = self.masks[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
         else:
             patch_origin_x = np.random.randint(0, self.W - patch_size)
             patch_origin_y = np.random.randint(0, self.H - patch_size)
@@ -241,36 +244,32 @@ class Dataset:
             pixels_x = (pixels_x + patch_origin_x).reshape(-1)
             pixels_y = (pixels_y + patch_origin_y).reshape(-1)
 
-            color = self.images[img_idx][(pixels_y, pixels_x)]    # batch_size, 3
-            mask = self.masks[img_idx][(pixels_y, pixels_x)]      # batch_size, 3
+            color = self.images[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
+            mask = self.masks[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
 
-        p = torch.stack([pixels_x+shift[0], pixels_y+shift[1], torch.ones_like(pixels_y)], dim=-1).float()  # batch_size, 3
-        p = torch.matmul(self.intrinsics_all_inv[img_idx, None, :3, :3], p[:, :, None]).squeeze() # batch_size, 3
-        rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)    # batch_size, 3
+        p = torch.stack([pixels_x + shift[0], pixels_y + shift[1], torch.ones_like(pixels_y)], dim=-1).float()  # batch_size, 3
+        p = torch.matmul(self.intrinsics_all_inv[img_idx, None, :3, :3], p[:, :, None]).squeeze()  # batch_size, 3
+        rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)  # batch_size, 3
         rays_v = torch.matmul(self.pose_all[img_idx, None, :3, :3], rays_v[:, :, None]).squeeze()  # batch_size, 3
-        rays_o = self.pose_all[img_idx, None, :3, 3].expand(rays_v.shape) # batch_size, 3
+        rays_o = self.pose_all[img_idx, None, :3, 3].expand(rays_v.shape)  # batch_size, 3
 
         if self.ignore_0:
-            mask = mask[:,:1] * (color.sum(-1) > 0).float()
+            mask = mask[:, :1] * (color.sum(-1) > 0).float()
         else:
-            mask = mask[:,:1]
+            mask = mask[:, :1]
 
         return torch.cat([rays_o.cpu(), rays_v.cpu(), color, mask], dim=-1).cuda()
 
-        
-
-
-
-    def gen_random_rays_at(self, img_idx, batch_size, foreground_only=True, shift=(0,0), seed=None):
+    def gen_random_rays_at(self, img_idx, batch_size, foreground_only=True, shift=(0, 0), seed=None):
         """
         Generate random rays at world space from one camera.
         """
         if seed is not None:
             np.random.seed(seed)
-        assert all((s-0.5)*(s+0.5)<=0 for s in shift)
+        assert all((s - 0.5) * (s + 0.5) <= 0 for s in shift)
         if foreground_only and (not self.no_mask):
             pixels_y, pixels_x = torch.meshgrid(torch.arange(self.H), torch.arange(self.W))
-            pixels_x = pixels_x[self.masks[img_idx].mean(-1) > 0.5] 
+            pixels_x = pixels_x[self.masks[img_idx].mean(-1) > 0.5]
             pixels_y = pixels_y[self.masks[img_idx].mean(-1) > 0.5]
 
             batch_size = min(len(pixels_x), batch_size)
@@ -282,20 +281,20 @@ class Dataset:
             pixels_x = torch.from_numpy(np.random.randint(low=0, high=self.W, size=[batch_size])).cuda()
             pixels_y = torch.from_numpy(np.random.randint(low=0, high=self.H, size=[batch_size])).cuda()
 
-        color = self.images[img_idx][(pixels_y, pixels_x)]    # batch_size, 3
-        mask = self.masks[img_idx][(pixels_y, pixels_x)]      # batch_size, 3
-        p = torch.stack([pixels_x+shift[0], pixels_y+shift[1], torch.ones_like(pixels_y)], dim=-1).float()  # batch_size, 3
-        p = torch.matmul(self.intrinsics_all_inv[img_idx, None, :3, :3], p[:, :, None]).squeeze() # batch_size, 3
-        rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)    # batch_size, 3
+        color = self.images[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
+        mask = self.masks[img_idx][(pixels_y, pixels_x)]  # batch_size, 3
+        p = torch.stack([pixels_x + shift[0], pixels_y + shift[1], torch.ones_like(pixels_y)], dim=-1).float()  # batch_size, 3
+        p = torch.matmul(self.intrinsics_all_inv[img_idx, None, :3, :3], p[:, :, None]).squeeze()  # batch_size, 3
+        rays_v = p / torch.linalg.norm(p, ord=2, dim=-1, keepdim=True)  # batch_size, 3
         rays_v = torch.matmul(self.pose_all[img_idx, None, :3, :3], rays_v[:, :, None]).squeeze()  # batch_size, 3
-        rays_o = self.pose_all[img_idx, None, :3, 3].expand(rays_v.shape) # batch_size, 3
+        rays_o = self.pose_all[img_idx, None, :3, 3].expand(rays_v.shape)  # batch_size, 3
 
         if self.ignore_0:
-            mask = mask[:,:1] * (color.sum(-1) > 0).float()
+            mask = mask[:, :1] * (color.sum(-1) > 0).float()
         else:
-            mask = mask[:,:1]
+            mask = mask[:, :1]
 
-        return torch.cat([rays_o.cpu(), rays_v.cpu(), color, mask], dim=-1).cuda()    # batch_size, 10
+        return torch.cat([rays_o.cpu(), rays_v.cpu(), color, mask], dim=-1).cuda()  # batch_size, 10
 
     def gen_light_params_between(self, idx_0, idx_1, ratio):
         trans = self.pose_all[idx_0, :3, 3] * (1.0 - ratio) + self.pose_all[idx_1, :3, 3] * ratio
@@ -356,7 +355,7 @@ class Dataset:
         return rays_o.transpose(0, 1), rays_v.transpose(0, 1)
 
     def near_far_from_sphere(self, rays_o, rays_d):
-        a = torch.sum(rays_d**2, dim=-1, keepdim=True)
+        a = torch.sum(rays_d ** 2, dim=-1, keepdim=True)
         b = 2.0 * torch.sum(rays_o * rays_d, dim=-1, keepdim=True)
         mid = 0.5 * (-b) / a
         near = mid - 1.0
@@ -373,14 +372,12 @@ class Dataset:
         if to256:
             img = img.clip(0, 255)
         return img
-    
+
     def mask_at(self, idx, resolution_level, to256=True):
         mask = self.masks[idx].numpy()
         mask = (cv.resize(mask, (self.W // resolution_level, self.H // resolution_level)))
 
         if to256:
             mask = (mask * 256).clip(0, 255)
-        
+
         return mask
-
-


### PR DESCRIPTION
Thanks a lot for that well designed code. I enjoyed digging into it, however I believe I found (and hopefully fixed) some bugs. Here's a list of what I intended to do :)

In `environ.yaml`:
- [update gdown](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-5a0005fb43a533c85b514e89575eef52efa3e3ca885aa0b1a478ce88c82ffabcL122-R122), such that `download_dataset` works as expected.

In `models/physicalshader.py`
- remove deprecated `F.sigmoid` dependency, use `torch.sigmoid` instead: [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-4f842b580fae1f2b4616c0da7ab19b9bbe1d4b94070e2346cffb402fb40eee66L44-R44), [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-4f842b580fae1f2b4616c0da7ab19b9bbe1d4b94070e2346cffb402fb40eee66L46-R46), and [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-4f842b580fae1f2b4616c0da7ab19b9bbe1d4b94070e2346cffb402fb40eee66L73-R74)

In `models/dataset.py`
- [remove hardcoded `'scale_mat_0'`, but get lexicographically ordered first scale_mat](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-2730a8c5bd5549f02454fcdfd4a30faef0d608acd1627662eacd9e71c765c6feL160-R163). This hardcoded value can cause troubles, if it doesn't exist, e.g. if the images do not start at 0

In `exp_runner.py`
- [print case and mode for easier traceback in log files](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458R56)
- if `--is_continue` is used, only search for checkpoints [if directory exists](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L133-R136) and [use pth files if exist](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L140-R143), otherwise behave as if `--is_continue` wasn't used. This is useful for automated queuing and restarting, e.g. in slurm
- fix bug where psnr and ssim could not be calculated due to different matrix sizes: [`stack` -> `concatenate`](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L215-R216)
- [fix bug where final state wasn't saved](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458R354-R363). It can happen that `iter_step` and `save_freq` do not fulfill `iter_step % self.save_freq == 0` in the last iteration, so the last checkpoint wouldn't be saved.
- add the correct number of leading zeros, otherwise wrong checkpoints might be used: [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L408-R419), [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L524-R542), [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L586-R596), [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L646-R653), and [here](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458L210-R211). While this might not be as problematic for non-checkpoint files, it can cause troubles when invoking load_checkpoint. Missing leading zeros in filenames can cause the [sort routine](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458R142) to not fetch the last generated checkpoint file.
- [save normals also as numpy array](https://github.com/za-cheng/WildLight/compare/main...BjoernHaefner:WildLight:main#diff-8ec156b6de3d1a818b5713fe4957da357e131bde40103060d48d0fcded78e458R542) to avoid discretization errors when computing MAEs


